### PR TITLE
Wrong usage of trades fees

### DIFF
--- a/coin2086/pnl.py
+++ b/coin2086/pnl.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 def add_portfolio_purchase_price(trades, initial_purchase_price):
     trades["portfolio_purchase_price"] = 0
     trades.loc[trades["trade_side"] == "BUY", "portfolio_purchase_price"] = (
-        trades["amount"] + trades["fee"]
+        trades["amount"] - trades["fee"]
     )
     trades["portfolio_purchase_price"] = trades["portfolio_purchase_price"].cumsum()
     trades["portfolio_purchase_price"] += initial_purchase_price


### PR DESCRIPTION
Trades fees were added to the portfolio_purchase_price instead of removed which led to an overestimated portfolio_purchase_price.

Easily testable with :
> BUY BTC 1 1000 EUR,1000 10
> SELL BTC 0.375 1200 EUR 450.0 3
> SELL BTC 0.625 2080 EUR 1300 7


Without the patch : [portfolio_purchase_price_net] = 1010
With the patch : [portfolio_purchase_price_net] = 990